### PR TITLE
Fiber solution 1

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -1437,10 +1437,50 @@ where
                             );
                             let epoch_delay_milliseconds = tlc_expiry_delay(&delay_epoch);
                             let expect_expiry = now + epoch_delay_milliseconds;
-                            for tlc in actor_state
+
+                            // Collect TLCs that need to be checked for on-chain settlement
+                            let expired_tlcs: Vec<_> = actor_state
                                 .tlc_state
                                 .get_expired_offered_tlcs(expect_expiry)
-                            {
+                                .filter(|tlc| tlc.forwarding_tlc.is_some())
+                                .collect();
+
+                            // Query watchtower for TLC status if standalone watchtower is configured
+                            #[cfg(not(target_arch = "wasm32"))]
+                            if !expired_tlcs.is_empty() {
+                                if let Some(ref watchtower_config) =
+                                    state.standalone_watchtower_config
+                                {
+                                    let tlc_queries: Vec<_> = expired_tlcs
+                                        .iter()
+                                        .map(|tlc| (channel_id, tlc.payment_hash))
+                                        .collect();
+
+                                    match watchtower_config.query_tlc_status(tlc_queries).await {
+                                        Ok(result) => {
+                                            // Sync preimages from watchtower to local store
+                                            for preimage_result in result.preimages {
+                                                debug!(
+                                                    "Syncing preimage from watchtower: payment_hash={:?}",
+                                                    preimage_result.payment_hash
+                                                );
+                                                self.store.insert_preimage(
+                                                    preimage_result.payment_hash,
+                                                    preimage_result.preimage,
+                                                );
+                                            }
+                                        }
+                                        Err(err) => {
+                                            warn!(
+                                                "Failed to query TLC status from watchtower for channel {:?}: {}",
+                                                channel_id, err
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+
+                            for tlc in expired_tlcs {
                                 if let Some((forwarding_channel_id, forwarding_tlc_id)) =
                                     tlc.forwarding_tlc
                                 {
@@ -2707,6 +2747,76 @@ pub struct NetworkActorState<S, C> {
 
     // Inflight payment actors
     inflight_payments: HashMap<Hash256, ActorRef<PaymentActorMessage>>,
+
+    // Standalone watchtower configuration for querying TLC status on-demand
+    #[cfg(not(target_arch = "wasm32"))]
+    standalone_watchtower_config: Option<StandaloneWatchtowerConfig>,
+}
+
+/// Configuration for standalone watchtower RPC
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+pub struct StandaloneWatchtowerConfig {
+    /// The RPC URL of the standalone watchtower
+    pub rpc_url: String,
+    /// The authentication token for the watchtower RPC
+    pub token: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl StandaloneWatchtowerConfig {
+    /// Query TLC status from the standalone watchtower for a specific channel.
+    /// Returns the preimages discovered on-chain for the given TLCs.
+    pub async fn query_tlc_status(
+        &self,
+        tlcs: Vec<(Hash256, Hash256)>, // Vec<(channel_id, payment_hash)>
+    ) -> Result<crate::rpc::watchtower::GetTlcStatusResult, String> {
+        use crate::rpc::watchtower::{GetTlcStatusParams, TlcQuery, WatchtowerRpcClient};
+        use jsonrpsee::http_client::HttpClientBuilder;
+
+        if tlcs.is_empty() {
+            return Ok(crate::rpc::watchtower::GetTlcStatusResult {
+                settled_tlcs: vec![],
+                preimages: vec![],
+            });
+        }
+
+        // Build the RPC client using the same approach as main.rs
+        let mut client_builder = HttpClientBuilder::default();
+
+        // Add authorization header if token is provided
+        if let Some(token) = &self.token {
+            use hyper::{header::HeaderValue, HeaderMap};
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "Authorization",
+                HeaderValue::from_str(&format!("Bearer {}", token))
+                    .map_err(|e| format!("Invalid token: {}", e))?,
+            );
+            client_builder = client_builder.set_headers(headers);
+        }
+
+        let client = client_builder
+            .build(&self.rpc_url)
+            .map_err(|e| format!("Failed to create watchtower client: {}", e))?;
+
+        // Build the query params
+        let params = GetTlcStatusParams {
+            tlcs: tlcs
+                .into_iter()
+                .map(|(channel_id, payment_hash)| TlcQuery {
+                    channel_id,
+                    payment_hash,
+                })
+                .collect(),
+        };
+
+        // Call the RPC
+        client
+            .get_tlc_status(params)
+            .await
+            .map_err(|e| format!("Failed to query TLC status: {}", e))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -4389,6 +4499,13 @@ where
                 funding_timeout_seconds: config.funding_timeout_seconds,
             },
             inflight_payments: Default::default(),
+            #[cfg(not(target_arch = "wasm32"))]
+            standalone_watchtower_config: config.standalone_watchtower_rpc_url.as_ref().map(
+                |url| StandaloneWatchtowerConfig {
+                    rpc_url: url.clone(),
+                    token: config.standalone_watchtower_token.clone(),
+                },
+            ),
         };
 
         let node_announcement = state.get_or_create_new_node_announcement_message();

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -61,6 +61,7 @@ You may refer to the e2e test cases in the `tests/bruno/e2e` directory for examp
         * [Method `update_local_settlement`](#watchtower-update_local_settlement)
         * [Method `create_preimage`](#watchtower-create_preimage)
         * [Method `remove_preimage`](#watchtower-remove_preimage)
+        * [Method `get_tlc_status`](#watchtower-get_tlc_status)
 * [RPC Types](#rpc-types)
 
     * [Type `Attribute`](#type-attribute)
@@ -84,6 +85,7 @@ You may refer to the e2e test cases in the `tests/bruno/e2e` directory for examp
     * [Type `PaymentCustomRecords`](#type-paymentcustomrecords)
     * [Type `PaymentStatus`](#type-paymentstatus)
     * [Type `PeerInfo`](#type-peerinfo)
+    * [Type `PreimageResult`](#type-preimageresult)
     * [Type `Privkey`](#type-privkey)
     * [Type `Pubkey`](#type-pubkey)
     * [Type `RemoveTlcReason`](#type-removetlcreason)
@@ -94,6 +96,7 @@ You may refer to the e2e test cases in the `tests/bruno/e2e` directory for examp
     * [Type `SettlementData`](#type-settlementdata)
     * [Type `SettlementTlc`](#type-settlementtlc)
     * [Type `TLCId`](#type-tlcid)
+    * [Type `TlcQuery`](#type-tlcquery)
     * [Type `TlcStatus`](#type-tlcstatus)
     * [Type `UdtArgInfo`](#type-udtarginfo)
     * [Type `UdtCellDep`](#type-udtcelldep)
@@ -1039,6 +1042,25 @@ Remove preimage
 
 
 
+<a id="watchtower-get_tlc_status"></a>
+#### Method `get_tlc_status`
+
+Get TLC status - check if TLCs are settled on-chain and get discovered preimages.
+ This is used by Fiber node to sync TLC settlement status from the watchtower.
+
+##### Params
+
+* `tlcs` - <em>Vec<[TlcQuery](#type-tlcquery)></em>, List of TLCs to check, each containing channel_id and payment_hash
+
+##### Returns
+
+* `settled_tlcs` - <em>Vec<[TlcQuery](#type-tlcquery)></em>, List of TLCs that are confirmed settled on-chain
+* `preimages` - <em>Vec<[PreimageResult](#type-preimageresult)></em>, List of (payment_hash, preimage) pairs for discovered preimages
+
+---
+
+
+
 
 ## RPC Types
 
@@ -1392,6 +1414,18 @@ The information about a peer connected to the node.
  The `graph_nodes` in Graph rpc module will return all addresses of the peer.
 ---
 
+<a id="#type-preimageresult"></a>
+### Type `PreimageResult`
+
+A preimage result containing payment hash and preimage
+
+
+#### Fields
+
+* `payment_hash` - <em>[Hash256](#type-hash256)</em>, Payment hash
+* `preimage` - <em>[Hash256](#type-hash256)</em>, Preimage
+---
+
 <a id="#type-privkey"></a>
 ### Type `Privkey`
 
@@ -1524,6 +1558,18 @@ The id of a tlc, it can be either offered or received.
 
 * `Offered` - <em>`u64`</em>, Offered tlc id
 * `Received` - <em>`u64`</em>, Received tlc id
+---
+
+<a id="#type-tlcquery"></a>
+### Type `TlcQuery`
+
+A single TLC query containing channel ID and payment hash
+
+
+#### Fields
+
+* `channel_id` - <em>[Hash256](#type-hash256)</em>, Channel ID
+* `payment_hash` - <em>[Hash256](#type-hash256)</em>, Payment hash
 ---
 
 <a id="#type-tlcstatus"></a>

--- a/crates/fiber-lib/src/rpc/watchtower.rs
+++ b/crates/fiber-lib/src/rpc/watchtower.rs
@@ -74,6 +74,15 @@ trait WatchtowerRpc {
         ctx: RpcContext,
         params: RemovePreimageParams,
     ) -> Result<(), ErrorObjectOwned>;
+
+    /// Get TLC status - check if TLCs are settled on-chain and get discovered preimages.
+    /// This is used by Fiber node to sync TLC settlement status from the watchtower.
+    #[method(name = "get_tlc_status")]
+    async fn get_tlc_status(
+        &self,
+        ctx: RpcContext,
+        params: GetTlcStatusParams,
+    ) -> Result<GetTlcStatusResult, ErrorObjectOwned>;
 }
 
 /// ignore rpc-doc-gen
@@ -122,6 +131,14 @@ trait WatchtowerRpc {
     /// Remove preimage
     #[method(name = "remove_preimage")]
     async fn remove_preimage(&self, params: RemovePreimageParams) -> Result<(), ErrorObjectOwned>;
+
+    /// Get TLC status - check if TLCs are settled on-chain and get discovered preimages.
+    /// This is used by Fiber node to sync TLC settlement status from the watchtower.
+    #[method(name = "get_tlc_status")]
+    async fn get_tlc_status(
+        &self,
+        params: GetTlcStatusParams,
+    ) -> Result<GetTlcStatusResult, ErrorObjectOwned>;
 }
 
 #[serde_as]
@@ -193,6 +210,44 @@ pub struct CreatePreimageParams {
 pub struct RemovePreimageParams {
     /// Payment hash
     pub payment_hash: Hash256,
+}
+
+/// Parameters for getting TLC settlement status from watchtower
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetTlcStatusParams {
+    /// List of TLCs to check, each containing channel_id and payment_hash
+    pub tlcs: Vec<TlcQuery>,
+}
+
+/// A single TLC query containing channel ID and payment hash
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TlcQuery {
+    /// Channel ID
+    pub channel_id: Hash256,
+    /// Payment hash
+    pub payment_hash: Hash256,
+}
+
+/// Result of TLC status query from watchtower
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetTlcStatusResult {
+    /// List of TLCs that are confirmed settled on-chain
+    pub settled_tlcs: Vec<TlcQuery>,
+    /// List of (payment_hash, preimage) pairs for discovered preimages
+    pub preimages: Vec<PreimageResult>,
+}
+
+/// A preimage result containing payment hash and preimage
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PreimageResult {
+    /// Payment hash
+    pub payment_hash: Hash256,
+    /// Preimage
+    pub preimage: Hash256,
 }
 
 #[cfg(feature = "watchtower")]
@@ -311,5 +366,51 @@ where
         self.store
             .remove_watch_preimage(ctx.node_id, params.payment_hash);
         Ok(())
+    }
+
+    async fn get_tlc_status(
+        &self,
+        _ctx: RpcContext,
+        params: GetTlcStatusParams,
+    ) -> Result<GetTlcStatusResult, ErrorObjectOwned> {
+        let mut settled_tlcs = Vec::new();
+        let mut payment_hashes = Vec::new();
+
+        for tlc in &params.tlcs {
+            // Extract the first 20 bytes of the payment hash for settled check
+            let payment_hash_prefix: [u8; 20] = tlc.payment_hash.as_ref()[0..20]
+                .try_into()
+                .expect("payment hash should be at least 20 bytes");
+
+            // Check if TLC is settled on-chain
+            if self
+                .store
+                .is_tlc_settled_with_prefix(&tlc.channel_id, &payment_hash_prefix)
+            {
+                settled_tlcs.push(TlcQuery {
+                    channel_id: tlc.channel_id,
+                    payment_hash: tlc.payment_hash,
+                });
+            }
+
+            // Collect payment hashes for preimage lookup
+            payment_hashes.push(tlc.payment_hash);
+        }
+
+        // Get preimages for the payment hashes
+        let preimages = self
+            .store
+            .get_preimages(&payment_hashes)
+            .into_iter()
+            .map(|(payment_hash, preimage)| PreimageResult {
+                payment_hash,
+                preimage,
+            })
+            .collect();
+
+        Ok(GetTlcStatusResult {
+            settled_tlcs,
+            preimages,
+        })
     }
 }

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -962,6 +962,30 @@ impl WatchtowerStore for Store {
         batch.put(key, []);
         batch.commit();
     }
+
+    fn is_tlc_settled_with_prefix(
+        &self,
+        channel_id: &Hash256,
+        payment_hash_prefix: &[u8; 20],
+    ) -> bool {
+        let key = [
+            &[WATCHTOWER_TLC_SETTLED_PREFIX],
+            channel_id.as_ref(),
+            payment_hash_prefix.as_ref(),
+        ]
+        .concat();
+        self.get(key).is_some()
+    }
+
+    fn get_preimages(&self, payment_hashes: &[Hash256]) -> Vec<(Hash256, Hash256)> {
+        payment_hashes
+            .iter()
+            .filter_map(|payment_hash| {
+                self.get_watch_preimage(payment_hash)
+                    .map(|preimage| (*payment_hash, preimage))
+            })
+            .collect()
+    }
 }
 
 impl GossipMessageStore for Store {

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -71,6 +71,17 @@ pub trait WatchtowerStore {
 
     /// Mark a tlc as settled on chain
     fn update_tlc_settled(&self, channel_id: &Hash256, payment_hash: [u8; 20]);
+
+    /// Check if a TLC is settled on chain using payment hash prefix (first 20 bytes)
+    fn is_tlc_settled_with_prefix(
+        &self,
+        channel_id: &Hash256,
+        payment_hash_prefix: &[u8; 20],
+    ) -> bool;
+
+    /// Get preimages for multiple payment hashes.
+    /// Returns a list of (payment_hash, preimage) pairs for the payment hashes that have preimages.
+    fn get_preimages(&self, payment_hashes: &[Hash256]) -> Vec<(Hash256, Hash256)>;
 }
 
 /// The data of a channel that the watchtower is monitoring


### PR DESCRIPTION
Add RPC methods to watchtower to query TLC settled status and preimages, and modify Fiber node to query this status on-demand.

This enables the Fiber node to update payment statuses when the watchtower settles TLCs on-chain, specifically for expired TLCs in force-closed channels, by querying the watchtower for settlement status and preimages. This ensures consistency between the Fiber node's payment state and on-chain settlements.

---
<a href="https://cursor.com/background-agent?bcId=bc-50e9b5a0-4dc6-4c9d-ad43-7bbde7ca10df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50e9b5a0-4dc6-4c9d-ad43-7bbde7ca10df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

