### PR TITLE
Add Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,3 +250,23 @@ CI runs the following checks (all must pass):
 - RPC API documentation: `crates/fiber-lib/src/rpc/README.md` (auto-generated)
 - Protocol specifications: `docs/specs/`
 - Development notes: `docs/notes/`
+
+## Cursor Cloud specific instructions
+
+### System dependency
+The VM's default `c++` is Clang 18 which selects the GCC 14 C++ stdlib, but only GCC 13 headers ship pre-installed. RocksDB (via `ckb-librocksdb-sys`) will fail to compile without `libstdc++-14-dev`. The update script installs it automatically.
+
+### Running the FNN binary locally
+FNN requires a CKB node RPC endpoint. The testnet config at `config/testnet/config.yml` points to `https://testnet.ckbapp.dev/` which works without a local CKB node. To run locally:
+```
+mkdir -p /tmp/fnn-test/ckb
+cp config/testnet/config.yml /tmp/fnn-test/
+python3 -c "import secrets; print(secrets.token_hex(32))" > /tmp/fnn-test/ckb/key
+FIBER_SECRET_KEY_PASSWORD='testpw' RUST_LOG=info ./target/debug/fnn -c /tmp/fnn-test/config.yml -d /tmp/fnn-test
+```
+
+### Testing notes
+- Use `cargo nextest run` (not `cargo test`). See AGENTS.md commands above.
+- `test_trampoline_routing_race_same_invoice` is a known flaky test; occasional failures are expected.
+- The full test suite (`-p fnn -p fiber-bin`) takes ~6-7 minutes. Individual tests are fast.
+- Build commands (especially first `cargo build`) take several minutes due to RocksDB C++ compilation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud specific instructions to `AGENTS.md` to support future cloud agent development sessions.

### Changes
- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
  - System dependency note: `libstdc++-14-dev` required for RocksDB compilation (Clang 18 + GCC 14 stdlib mismatch)
  - Instructions for running the FNN binary locally using the testnet config
  - Testing notes: preferred test runner, known flaky test, and build time expectations

### Environment Setup (captured in VM update script)
- Installs `libstdc++-14-dev` (C++ stdlib headers for RocksDB)
- Installs Rust toolchain via `rust-toolchain.toml` (1.93.0)
- Installs `cargo-nextest`, `typos-cli`, `cargo-shear` build/test tools

### Verification
- `cargo build` — compiles successfully
- `cargo fmt --all -- --check` — passes
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings` — passes
- `typos` — passes
- `cargo nextest run -p fnn -p fiber-bin` — 765 tests: 764 passed, 1 flaky, 7 skipped
- `fnn` binary starts and connects to CKB testnet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85087b6a-b784-49ad-8875-2341afe91ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85087b6a-b784-49ad-8875-2341afe91ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

